### PR TITLE
setup a default replica_server_id if client_id is set

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -232,7 +232,15 @@ public class MaxwellConfig extends AbstractConfig {
 		this.producerType       = fetchOption("producer", options, properties, "stdout");
 		this.bootstrapperType   = fetchOption("bootstrapper", options, properties, "async");
 		this.clientID           = fetchOption("client_id", options, properties, "maxwell");
-		this.replicaServerID    = fetchLongOption("replica_server_id", options, properties, 6379L);
+
+		long defaultReplicaServerID = 6379;
+		/* if the user is giving us a client_id, we'll assume that they're using multiple
+		 * maxwells and setup a different default replica_server_id.  Should be close enough
+		 * for government work. */
+		if ( !"maxwell".equals(this.clientID) )
+			defaultReplicaServerID = Math.abs(this.clientID.hashCode());
+
+		this.replicaServerID    = fetchLongOption("replica_server_id", options, properties, defaultReplicaServerID);
 
 		this.kafkaTopic         	= fetchOption("kafka_topic", options, properties, "maxwell");
 		this.kafkaKeyFormat     	= fetchOption("kafka_key_format", options, properties, "hash");


### PR DESCRIPTION
should help prevent confusion like in #466, and also should be mostly
harmless.